### PR TITLE
Fix video-seed.dev URL extraction

### DIFF
--- a/addon.js
+++ b/addon.js
@@ -2123,15 +2123,16 @@ ${titleSecondLine}` : displayTitle;
 ${warningMessage}`;
         }
 
+        // Use provider's behaviorHints if available, otherwise default to notWebReady: true
+        const behaviorHints = stream.behaviorHints || { notWebReady: true };
+
         return {
             name: nameDisplay,
             title: finalTitle,
             url: stream.url,
             type: 'url', // CRITICAL: This is the type of the stream itself, not the content
             availability: 2,
-            behaviorHints: {
-                notWebReady: true // As per the working example, indicates Stremio might need to handle it carefully or use external player
-            }
+            behaviorHints: behaviorHints
         };
     });
 

--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,14 @@
     {
       "src": "server.js",
       "use": "@vercel/node",
-      "config": { "includeFiles": ["providers/**", "views/**"] }
+      "config": {
+        "maxDuration": 60,
+        "memory": 1024,
+        "includeFiles": [
+          "providers/**",
+          "views/**"
+        ]
+      }
     }
   ],
   "routes": [


### PR DESCRIPTION
## What This Fixes
UHDMovies was returning broken video links that couldn't be played in Stremio. The links looked like:

https://video-seed.dev/?url=https://actual-video-file.com


## Changes Made
**Modified UHDMovies scraper** ([providers/uhdmovies.js](cci:7://file:///home/yat/NuvioStreamsAddon/providers/uhdmovies.js:0:0-0:0)):
- Added support for `video-seed.dev` domain (was only handling `video-seed.pro`)
- Updated URL extraction to get the direct video link from the `?url=` parameter
## Result
UHDMovies now returns direct, playable video url 

## Note

- i also made some changes in addon.js as to improve seeking for uhdmovies but it dont seem to wolrk properly though it worked on some stream i cant identify whats the problem
